### PR TITLE
Add Cognito test stack for RabbitMQ OAuth2 plugin

### DIFF
--- a/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/.gitignore
+++ b/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+*.js
+*.d.ts
+cdk.out/
+.env
+package-lock.json

--- a/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/README.md
+++ b/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/README.md
@@ -1,0 +1,117 @@
+# RabbitMQ OAuth2 with AWS Cognito
+
+This CDK project deploys the prerequisite AWS resources needed to test RabbitMQ OAuth2 integration.
+
+This stack creates the Cognito User Pool and related OAuth2 resources required before configuring RabbitMQ with OAuth2 authentication and authorization.
+
+## Step 0: Prerequisites
+
+1. Access to an AWS account.
+2. An AWS IAM user/Principal with the required permissions to deploy the infrastructure.
+3. AWS CDK CLI installed and configured.
+
+## Step 1: Install dependencies
+
+1. Navigate to the project directory:
+   ```bash
+   cd rabbitmq-oauth2-cognito-sample
+   ```
+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+## Step 2: Set required environment variables
+
+Before building or deploying, you must set these environment variables with your desired test user credentials:
+
+```bash
+export RABBITMQ_OAUTH2_MANAGEMENT_CONSOLE_TEST_USER_NAME="your-username"
+export RABBITMQ_OAUTH2_MANAGEMENT_CONSOLE_TEST_USER_PASSWORD="your-password"
+```
+
+### Optional: Callback and Logout URLs
+
+If you already have an existing RabbitMQ broker, you can specify the callback and logout URLs:
+
+```bash
+export RABBITMQ_OAUTH2_CALLBACK_URLS="https://your-rabbitmq-host/js/oidc-oauth/login-callback.html"
+export RABBITMQ_OAUTH2_LOGOUT_URLS="https://your-rabbitmq-host/js/oidc-oauth/logout-callback.html"
+```
+
+For multiple brokers, separate URLs with commas:
+
+```bash
+export RABBITMQ_OAUTH2_CALLBACK_URLS="https://rabbitmq-host-1/js/oidc-oauth/login-callback.html,https://rabbitmq-host-2/js/oidc-oauth/login-callback.html"
+export RABBITMQ_OAUTH2_LOGOUT_URLS="https://rabbitmq-host-1/js/oidc-oauth/logout-callback.html,https://rabbitmq-host-2/js/oidc-oauth/logout-callback.html"
+```
+
+If not provided, placeholder URLs will be used (see Step 5 to update them later).
+
+### Password Requirements
+
+The password must meet [Cognito's password policy requirements](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html):
+- Minimum 8 characters
+- At least one uppercase letter
+- At least one lowercase letter  
+- At least one number
+- At least one special character
+
+## Step 3: Build and deploy the stack
+
+1. Build the project:
+   ```bash
+   cdk synth
+   ```
+
+2. Deploy the CDK stack:
+
+```bash
+cdk deploy
+```
+
+The deployment takes approximately 2-3 minutes.
+
+## Step 4: Retrieve the outputs
+
+Once deployment is complete, the stack will output the following values needed for configuring RabbitMQ:
+
+- **UserPoolId**: The ID of the Cognito User Pool
+- **UserPoolDomainName**: The domain name for OAuth2 endpoints
+- **AmqpAppClientId**: Client ID for AMQP connections (with secret)
+- **AmqpAppClientSecret**: Client secret for AMQP connections
+- **ManagementConsoleAppClientId**: Client ID for management console access (no secret)
+- **JwksUri**: URI for token validation
+- **TokenEndpoint**: OAuth2 token endpoint
+
+## Step 5: Update callback URLs (if using placeholder URLs)
+
+If you didn't specify callback URLs in Step 2, you must update them after creating your RabbitMQ broker for management console OAuth2 login to work:
+
+1. Create your RabbitMQ broker with OAuth2 configuration
+2. Go to the Cognito console and select the **RabbitMqOAuth2TestUserPool** user pool
+3. Navigate to **App clients** → **RabbitMqManagementConsoleAppClient** → **Login pages** → **Allowed callback URLs**
+4. Replace the placeholder URLs with your actual RabbitMQ host URLs
+
+## Resources Created
+
+- **Cognito User Pool**: Manages user authentication
+- **Cognito User Pool Domain**: Provides OAuth2 endpoints with unique identifier
+- **Resource Server**: Defines RabbitMQ-specific OAuth2 scopes
+- **AMQP App Client**: Configured for client credentials flow (with secret)
+- **Management Console App Client**: Configured for authorization code flow (no secret)
+- **Test User**: Created with specified username and password
+- **OAuth2 Scopes**: 
+  - `rabbitmq/read:all` - Read permission for vhosts and queues
+  - `rabbitmq/write:all` - Write permission for vhosts and queues
+  - `rabbitmq/configure:all` - Configure permission for vhosts and queues
+  - `rabbitmq/tag:administrator` - Administrator tag permission
+
+## Cleanup
+
+To remove all resources created by this stack:
+
+```bash
+cdk destroy
+```

--- a/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/bin/app.ts
+++ b/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/bin/app.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { RabbitMqOAuth2TestStack } from '../lib/rabbitmq-oauth2-test-stack';
+
+const app = new cdk.App();
+
+const managementConsoleTestUserPassword = process.env.RABBITMQ_OAUTH2_MANAGEMENT_CONSOLE_TEST_USER_PASSWORD;
+const managementConsoleTestUserName = process.env.RABBITMQ_OAUTH2_MANAGEMENT_CONSOLE_TEST_USER_NAME;
+const callbackUrls = process.env.RABBITMQ_OAUTH2_CALLBACK_URLS ? process.env.RABBITMQ_OAUTH2_CALLBACK_URLS.split(',') : undefined;
+const logoutUrls = process.env.RABBITMQ_OAUTH2_LOGOUT_URLS ? process.env.RABBITMQ_OAUTH2_LOGOUT_URLS.split(',') : undefined;
+
+if (!managementConsoleTestUserPassword) {
+  throw new Error('RABBITMQ_OAUTH2_MANAGEMENT_CONSOLE_TEST_USER_PASSWORD environment variable is required');
+}
+
+if (!managementConsoleTestUserName) {
+  throw new Error('RABBITMQ_OAUTH2_MANAGEMENT_CONSOLE_TEST_USER_NAME environment variable is required');
+}
+
+new RabbitMqOAuth2TestStack(app, 'RabbitMqOAuth2TestStack', {
+  userPoolName: 'RabbitMqOAuth2TestUserPool',
+  domainPrefix: 'rabbitmq-oauth2-test',
+  callbackUrls,
+  logoutUrls,
+  managementConsoleTestUserPassword,
+  managementConsoleTestUserName,
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});

--- a/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/cdk.json
+++ b/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/cdk.json
@@ -1,0 +1,61 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/app.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target": "aws-cdk-lib",
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableLogging": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+    "@aws-cdk/aws-opensearchservice:enableLogging": true,
+    "@aws-cdk/aws-nordicapis-v10migration:enabled": true,
+    "@aws-cdk/aws-logs:inquirerjs": true,
+    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+    "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForSourceAction": true
+  }
+}

--- a/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/lib/rabbitmq-oauth2-test-stack.ts
+++ b/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/lib/rabbitmq-oauth2-test-stack.ts
@@ -1,0 +1,185 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as cr from 'aws-cdk-lib/custom-resources';
+
+export enum RabbitMQOAuthScope {
+  READALL = 'read:all',
+  WRITEALL = 'write:all',
+  CONFIGUREALL = 'configure:all',
+  TAGADMINISTRATOR = 'tag:administrator'
+}
+
+export interface OAuthTestStackProps extends cdk.StackProps {
+  userPoolName: string;
+  domainPrefix: string;
+  callbackUrls?: string[];
+  logoutUrls?: string[];
+  managementConsoleTestUserPassword: string;
+  managementConsoleTestUserName: string;
+}
+
+export class RabbitMqOAuth2TestStack extends cdk.Stack {
+  public readonly userPool: cognito.UserPool;
+  public readonly userPoolDomain: cognito.UserPoolDomain;
+  public readonly amqpAppClient: cognito.UserPoolClient;
+  public readonly managementConsoleAppClient: cognito.UserPoolClient;
+
+  constructor(scope: Construct, id: string, props: OAuthTestStackProps) {
+    super(scope, id, props);
+
+    if (!props.managementConsoleTestUserPassword) {
+      throw new Error('managementConsoleTestUserPassword is required');
+    }
+
+    const defaultCallbackUrls = [`https://b-<your-broker-id>.${this.region}.on.aws/js/oidc-oauth/login-callback.html`];
+    const defaultLogoutUrls = [`https://b-<your-broker-id>.${this.region}.on.aws/js/oidc-oauth/logout-callback.html`];
+    
+    const callbackUrls = props.callbackUrls || defaultCallbackUrls;
+    const logoutUrls = props.logoutUrls || defaultLogoutUrls;
+
+    this.userPool = new cognito.UserPool(this, 'UserPool', {
+      userPoolName: props.userPoolName,
+      removalPolicy: cdk.RemovalPolicy.DESTROY
+    });
+
+    this.userPoolDomain = this.userPool.addDomain('UserPoolDomain', {
+      cognitoDomain: {
+        domainPrefix: `${props.domainPrefix}-${this.node.addr}`,
+      },
+    });
+
+    const resourceServerIdentifier = 'rabbitmq';
+
+    const resourceServerScopes: cognito.CfnUserPoolResourceServer.ResourceServerScopeTypeProperty[] = [
+      {
+        scopeName: RabbitMQOAuthScope.READALL,
+        scopeDescription: 'Read permission for all vhosts and resources'
+      },
+      {
+        scopeName: RabbitMQOAuthScope.WRITEALL,
+        scopeDescription: 'Write permission for all vhosts and resources'
+      },
+      {
+        scopeName: RabbitMQOAuthScope.CONFIGUREALL,
+        scopeDescription: 'Configure permission for all vhosts and resources'
+      },
+      {
+        scopeName: RabbitMQOAuthScope.TAGADMINISTRATOR,
+        scopeDescription: 'Administrator tag permission'
+      }
+    ];
+
+    const resourceServer = new cognito.CfnUserPoolResourceServer(this, 'RabbitMQResourceServer', {
+      identifier: resourceServerIdentifier,
+      name: resourceServerIdentifier,
+      userPoolId: this.userPool.userPoolId,
+      scopes: resourceServerScopes
+    });
+
+    const allowedScopes = [
+      `${resourceServerIdentifier}/${RabbitMQOAuthScope.READALL}`,
+      `${resourceServerIdentifier}/${RabbitMQOAuthScope.WRITEALL}`,
+      `${resourceServerIdentifier}/${RabbitMQOAuthScope.CONFIGUREALL}`,
+      `${resourceServerIdentifier}/${RabbitMQOAuthScope.TAGADMINISTRATOR}`
+    ];
+
+    this.amqpAppClient = this.userPool.addClient('RabbitMqAmqpAppClient', {
+      userPoolClientName: 'RabbitMqAmqpAppClient',
+      generateSecret: true,
+      oAuth: {
+        flows: {
+          authorizationCodeGrant: false,
+          implicitCodeGrant: false,
+          clientCredentials: true,
+        },
+        scopes: allowedScopes.map(scope => cognito.OAuthScope.custom(scope)),
+        callbackUrls: callbackUrls,
+        logoutUrls: logoutUrls,
+      }
+    });
+
+    this.managementConsoleAppClient = this.userPool.addClient('RabbitMqManagementConsoleAppClient', {
+      userPoolClientName: 'RabbitMqManagementConsoleAppClient',
+      generateSecret: false,
+      oAuth: {
+        flows: {
+          authorizationCodeGrant: true,
+          implicitCodeGrant: false,
+          clientCredentials: false,
+        },
+        scopes: allowedScopes.map(scope => cognito.OAuthScope.custom(scope)),
+        callbackUrls: callbackUrls,
+        logoutUrls: logoutUrls,
+      }
+    });
+
+    this.amqpAppClient.node.addDependency(resourceServer);
+    this.managementConsoleAppClient.node.addDependency(resourceServer);
+
+    const testUser = new cognito.CfnUserPoolUser(this, 'ManagementConsoleTestUser', {
+      userPoolId: this.userPool.userPoolId,
+      username: props.managementConsoleTestUserName,
+      messageAction: 'SUPPRESS'
+    });
+
+    new cr.AwsCustomResource(this, 'SetUserPassword', {
+      onCreate: {
+        service: 'CognitoIdentityServiceProvider',
+        action: 'adminSetUserPassword',
+        parameters: {
+          UserPoolId: this.userPool.userPoolId,
+          Username: props.managementConsoleTestUserName,
+          Password: props.managementConsoleTestUserPassword,
+          Permanent: true
+        },
+        physicalResourceId: cr.PhysicalResourceId.of('set-user-password')
+      },
+      policy: cr.AwsCustomResourcePolicy.fromSdkCalls({
+        resources: cr.AwsCustomResourcePolicy.ANY_RESOURCE
+      })
+    }).node.addDependency(testUser);
+
+    new cdk.CfnOutput(this, 'UserPoolId', {
+      value: this.userPool.userPoolId,
+      description: 'The ID of the Cognito User Pool',
+      exportName: `${this.stackName}-UserPoolId`,
+    });
+
+    new cdk.CfnOutput(this, 'UserPoolDomainName', {
+      value: this.userPoolDomain.domainName,
+      description: 'The domain name of the Cognito User Pool',
+      exportName: `${this.stackName}-UserPoolDomainName`,
+    });
+
+    new cdk.CfnOutput(this, 'AmqpAppClientId', {
+      value: this.amqpAppClient.userPoolClientId,
+      description: 'The ID of the Cognito User Pool Client for RabbitMQ',
+      exportName: `${this.stackName}-AmqpAppClientId`,
+    });
+
+    new cdk.CfnOutput(this, 'AmqpAppClientSecret', {
+      value: this.amqpAppClient.userPoolClientSecret.unsafeUnwrap(),
+      description: 'The secret of the Cognito User Pool Client for RabbitMQ',
+      exportName: `${this.stackName}-AmqpAppClientSecret`,
+    });
+
+    new cdk.CfnOutput(this, 'ManagementConsoleAppClientId', {
+      value: this.managementConsoleAppClient.userPoolClientId,
+      description: 'The ID of the Management Console App Client',
+      exportName: `${this.stackName}-ManagementConsoleAppClientId`,
+    });
+
+    new cdk.CfnOutput(this, 'JwksUri', {
+      value: `https://cognito-idp.${this.region}.amazonaws.com/${this.userPool.userPoolId}/.well-known/jwks.json`,
+      description: 'JWKS URI for token validation',
+      exportName: `${this.stackName}-JwksUri`,
+    });
+
+    new cdk.CfnOutput(this, 'TokenEndpoint', {
+      value: `https://${this.userPoolDomain.domainName}.auth.${this.region}.amazoncognito.com/oauth2/token`,
+      description: 'OAuth2 token endpoint',
+      exportName: `${this.stackName}-TokenEndpoint`,
+    });
+  }
+}

--- a/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/package.json
+++ b/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "amazon-mq-rabbitmq-cognito-oauth2",
+  "version": "1.0.0",
+  "description": "CDK project for Amazon MQ RabbitMQ with Cognito OAuth2 integration",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "cdk": "cdk",
+    "deploy": "cdk deploy",
+    "synth": "cdk synth"
+  },
+  "keywords": [
+    "aws",
+    "cdk",
+    "rabbitmq",
+    "cognito",
+    "oauth2"
+  ],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "aws-cdk-lib": "^2.100.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.21",
+    "ts-node": "^10.9.2"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "typescript": "^4.9.0"
+  }
+}

--- a/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/tsconfig.json
+++ b/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "exclude": ["cdk.out"]
+}


### PR DESCRIPTION

*Description of changes:* Sample CDK stack that sets up Amazon Cognito resources to be used as an IdP provider for RabbitMQ similar to https://www.rabbitmq.com/docs/oauth2-examples


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
