### PR TITLE
Fix issue with cognito domain name not being unique across users

### DIFF
--- a/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/lib/rabbitmq-oauth2-test-stack.ts
+++ b/rabbitmq-samples/rabbitmq-oauth2-cognito-sample/lib/rabbitmq-oauth2-test-stack.ts
@@ -45,7 +45,7 @@ export class RabbitMqOAuth2TestStack extends cdk.Stack {
 
     this.userPoolDomain = this.userPool.addDomain('UserPoolDomain', {
       cognitoDomain: {
-        domainPrefix: `${props.domainPrefix}-${this.node.addr}`,
+        domainPrefix: `${props.domainPrefix}-${Math.random().toString(36).substring(2, 8)}`,
       },
     });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Currently if more than one user tries to deploy the stack at the same time, they will face errors since the domain name already exists. This change modifies the suffix from the CDK construct id to a random string.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
