### PR TITLE
replace link to ldap tutorial with links to mtls and ssl tutorials

### DIFF
--- a/rabbitmq-samples/rabbitmq-mtls-sample/README.md
+++ b/rabbitmq-samples/rabbitmq-mtls-sample/README.md
@@ -1,6 +1,6 @@
 # Amazon MQ for RabbitMQ mTLS Sample CDK
 
-This CDK project deploys the prerequisite AWS resources needed to test Amazon MQ for RabbitMQ mTLS or SSL feature as described in the [AWS documentation](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-ldap-tutorial.html).
+This CDK project deploys the prerequisite AWS resources needed to test Amazon MQ for RabbitMQ mTLS or SSL feature as described in the AWS documentation for [SSL plugin](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-ssl-tutorial.html) and [mTLS](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-mtls-tutorial.html).
 
 This stack creates the supporting infrastructure required before configuring Amazon MQ for RabbitMQ to use mTLS.
 


### PR DESCRIPTION

*Description of changes:* add links from mtls sample readme to mtls and ssl tutorials


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
